### PR TITLE
ENH: allow threshold for mat2axangle precision

### DIFF
--- a/transforms3d/axangles.py
+++ b/transforms3d/axangles.py
@@ -112,12 +112,16 @@ def axangle2aff(axis, angle, point=None):
     return M
 
 
-def mat2axangle(mat):
+def mat2axangle(mat, unit_thresh=1e-5):
     """Return axis, angle and point from (3, 3) matrix `mat`
 
     Parameters
     ----------
     mat : array-like shape (3, 3)
+        Rotation matrix
+    unit_thresh : float, optional
+        Tolerable difference from 1 when testing for unit eigenvalues to
+        confirm `mat` is a rotation matrix.
 
     Returns
     -------
@@ -143,7 +147,7 @@ def mat2axangle(mat):
     M = np.asarray(mat, dtype=np.float)
     # direction: unit eigenvector of R33 corresponding to eigenvalue of 1
     L, W = np.linalg.eig(M.T)
-    i = np.where(abs(np.real(L) - 1.0) < 1e-8)[0]
+    i = np.where(np.abs(L - 1.0) < unit_thresh)[0]
     if not len(i):
         raise ValueError("no unit eigenvector corresponding to eigenvalue 1")
     direction = np.real(W[:, i[-1]]).squeeze()

--- a/transforms3d/tests/test_axangles.py
+++ b/transforms3d/tests/test_axangles.py
@@ -9,7 +9,7 @@ from .. import taitbryan as ttb
 
 from .samples import euler_tuples
 
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_almost_equal
 
 from nose.tools import assert_raises
 
@@ -40,6 +40,24 @@ def test_aa_points():
                 # do round trip
                 RP_back = axangle2aff(v3, t3, p3)
                 assert_array_almost_equal(RP, RP_back)
+
+
+def test_mat2axangle_thresh():
+    # Test precision threshold to mat2axangle
+    axis, angle = mat2axangle(np.eye(3))
+    assert_almost_equal(axis, [0, 0, 1])
+    assert_almost_equal(angle, 0)
+    offset = 1e-6
+    mat = np.diag([1 + offset] * 3)
+    axis, angle = mat2axangle(mat)
+    assert_almost_equal(axis, [0, 0, 1])
+    assert_almost_equal(angle, 0)
+    offset = 1e-4
+    mat = np.diag([1 + offset] * 3)
+    assert_raises(ValueError, mat2axangle, mat)
+    axis, angle = mat2axangle(mat, 1e-4)
+    assert_almost_equal(axis, [0, 0, 1])
+    assert_almost_equal(angle, 0)
 
 
 def test_angle_axis_imps():


### PR DESCRIPTION
Allow user to set precision for mat2axangle check for rotation matrix 
precision.

Make default threshold more liberal.

Closes gh-3