### PR TITLE
pull fixes from nipy/nipy

### DIFF
--- a/transforms3d/__init__.py
+++ b/transforms3d/__init__.py
@@ -4,6 +4,7 @@ Based on, largely using transformations.py by Christoph Gohlke
 
 Additional code monkey work by Matthew Brett
 '''
+from __future__ import absolute_import
 
 from . import taitbryan
 from . import affines

--- a/transforms3d/axangles.py
+++ b/transforms3d/axangles.py
@@ -22,7 +22,7 @@ def axangle2mat(axis, angle, is_normalized=False):
     axis : 3 element sequence
        vector specifying axis for rotation.
     angle : scalar
-       angle of rotation in radians.
+       angle of rotation.
     is_normalized : bool, optional
        True if `axis` is already normalized (has norm of 1).  Default False.
 

--- a/transforms3d/tests/samples.py
+++ b/transforms3d/tests/samples.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import numpy as np
 
 from ..utils import inique, permuted_signs, permuted_with_signs

--- a/transforms3d/utils.py
+++ b/transforms3d/utils.py
@@ -1,4 +1,5 @@
 ''' Utilities for transforms3d '''
+from __future__ import absolute_import
 
 import math
 from itertools import permutations


### PR DESCRIPTION
Commits:

```
commit c7ae00435ef1134cee28eb0d31d2f1a253328f6b
Author: Matthew Brett <matthew.brett@gmail.com>

    RF: more Python 3 fixes from python-modernize

commit 37831e587f88a928912fc9b82ba1e813eb7c9160
Author: Matthew Brett <matthew.brett@gmail.com>

    RF: lists from Python 3 iterators

commit 54953d06312dd4a044d47c20401e6f7eaa959232
Author: Matthew Brett <matthew.brett@gmail.com>

    RF: get reduce from function functools

commit 27271ad67ae58f23c4d606c43ece171a2adb53b5
Author: Matthew Brett <matthew.brett@gmail.com>

    RF: delete implemention of itertools.permutations

commit 4f74d7c7da01c5ccc6b31f47aebd00e8ac009215
Author: Matthew Brett <matthew.brett@gmail.com>

    BF - fix doctest floating point display error

commit 33aef079855462498432f611e00953dde386bc12
Author: Alexis Roche <alexis.roche@gmail.com>

    apply Matthew's suggested fix for infinite quaternions

commit 96cea13ac22cbfc369c6ab2c7f854528be9d8ad9
Author: Alexis Roche <alexis.roche@gmail.com>

    fixing nan issue in quaterions (from externals)

commit 81f6b0c750744b4296bc8d8f816f7e58567c82c7
Author: Matthew Brett <matthew.brett@gmail.com>

    BF - remove in-place divide - numpy 2 casting rule

commit 5bcd4dd6ef36e72aec2c7ae6e77bea6d428d2c8c
Author: Yaroslav Halchenko <debian@onerussian.com>

    BF: add needed setup.py and __init__.py to guarantee installation of tests

commit 2ff49be4ecf3b322bac79aff8875378515415600
Author: Gael varoquaux <gael.varoquaux@normalesup.org>

    BUG: Fix imports in taitbryan

commit 98be1e4fede37ff91ec8900f86396bbe4be07407
Author: Alexis Roche <alexis.roche@gmail.com>

    fixing a math domain error in quaternions

commit 6a6a6519fc3e5c275a61c8727b9002a3a2ae6b42
Author: Matthew Brett <matthew.brett@gmail.com>

    BF - use quaternions mathematics from transforms3d package for affine->vector
```

Reference: https://github.com/matthew-brett/transforms3d/issues/6
Signed-off-by: Igor Gnatenko i.gnatenko.brain@gmail.com
