### PR TITLE
BF: fix numpy 1.11 warning for float as array size

### DIFF
--- a/transforms3d/shears.py
+++ b/transforms3d/shears.py
@@ -70,6 +70,7 @@ def striu2mat(striu):
         if N != math.floor(N):
             raise ValueError('%d is a strange number of shear elements' %
                              n)
+        N = int(N)
         inds = np.triu(np.ones((N,N)), 1).astype(bool)
     M = np.eye(N)
     M[inds] = striu


### PR DESCRIPTION
Numpy 1.11 complains about (integer) float value as dimension length
input to np.ones.