### PR TITLE
Fix “latex” target in doc/Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -83,7 +83,7 @@ qthelp:
 	@echo "To view the help file:"
 	@echo "# assistant -collectionFile _build/qthelp/transforms3d.qhc"
 
-latex: generate
+latex: api-stamp
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) _build/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in _build/latex."


### PR DESCRIPTION
Depend on “api-stamp” instead of a nonexistent “generate” target.