### PR TITLE
Add Transform Tree inspired by ROS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 #
 # Check setup.py when updating dependencies
 numpy>=1.15
+igraph>=0.10.2

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,5 @@ setup(name='transforms3d',
       zip_safe=False,
       python_requires = '>=3.6',
       # Check dependencies also in .github/workflows/testing.yml file
-      requires=['numpy (>=1.15)']
+      requires=['numpy (>=1.15)', 'igraph (>=0.10.2)']
       )

--- a/transforms3d/tests/test_transform_graph.py
+++ b/transforms3d/tests/test_transform_graph.py
@@ -1,11 +1,12 @@
-from transforms3d.transform_graph import Transformation, create_tranformation_graph
+from transforms3d.transform_graph import Transformation, create_tranformation_graph, get_tranformation_matrix
 import numpy as np
 import igraph as ig
 
 
 def test_create_tranformation_graph():
 
-    T = np.zeros((4,4))
+    # T = np.zeros((4,4), dtype=float)
+    T = np.identity(4)
     wizard_transforms = [
         Transformation("world", "left_hand", T),
         Transformation("world", "right_hand", T),
@@ -16,3 +17,7 @@ def test_create_tranformation_graph():
 
     g = create_tranformation_graph(wizard_transforms)
     assert isinstance(g, ig.Graph)
+
+    H = get_tranformation_matrix(g, "world", "page_corner")
+
+    assert isinstance(H, np.ndarray)

--- a/transforms3d/tests/test_transform_graph.py
+++ b/transforms3d/tests/test_transform_graph.py
@@ -1,6 +1,73 @@
 from transforms3d.transform_graph import Transformation, create_tranformation_graph, get_tranformation_matrix
 import numpy as np
 import igraph as ig
+import math
+import pytest
+
+from transforms3d.euler import euler2mat
+from transforms3d.affines import compose
+
+
+def define_ros_transform(x, y, z, roll, pitch, yaw, deg: bool = False):
+
+    if deg:
+        roll, pitch, yaw = math.radians(roll), math.radians(pitch), math.radians(yaw)
+
+    R = euler2mat(roll, pitch, yaw, axes="rxyz")
+    t = np.array([x, y, z])
+
+    H = compose(t, R, np.ones((3,)))
+    # equals to
+    # H = np.zeros((4, 4))
+    # H[:3, :3] = R
+    # H[:3, 3] = t
+    # H[3, 3] = 1.0
+    return H
+
+
+def vector_with_one(x, y, z):
+    v = np.ones((4))
+    v[:3] = [x, y ,z]
+    return v
+
+
+def test_simple_world():
+
+    world_to_baloon = Transformation("world", "baloon",
+        define_ros_transform(50, 50, 50, 0, 0, 0))
+    world_to_dragon = Transformation("world", "dragon",
+        define_ros_transform(-50, 0, 50, 3.0, -3.0, 0, deg=True))
+
+    simple_world_transforms = [
+        world_to_baloon,
+        world_to_dragon,
+    ]
+
+    g = create_tranformation_graph(simple_world_transforms)
+    assert isinstance(g, ig.Graph)
+
+    H = get_tranformation_matrix(g, "dragon", "baloon")
+
+    H_inv = get_tranformation_matrix(g, "baloon", "dragon")
+
+    dragon_origin = vector_with_one(0, 0, 0)
+    dragon_in_baloons_eyes = H_inv @ dragon_origin
+    dist_in_baloons_eyes = math.dist(dragon_in_baloons_eyes[:3], [0, 0, 0])
+
+    assert isinstance(H, np.ndarray)
+
+    baloon_origin = vector_with_one(0, 0, 0)
+    baloon_in_dragons_eyes = H @ baloon_origin
+
+    dist_in_dragons_eyes = math.dist(baloon_in_dragons_eyes[:3], [0, 0, 0])
+    assert dist_in_dragons_eyes > 75.0
+
+    assert pytest.approx(0) == (dist_in_baloons_eyes - dist_in_dragons_eyes)
+
+    x, y, z = baloon_in_dragons_eyes[:3]
+    assert z < 0
+    assert y > 40
+
 
 
 def test_create_tranformation_graph():

--- a/transforms3d/tests/test_transform_graph.py
+++ b/transforms3d/tests/test_transform_graph.py
@@ -1,0 +1,18 @@
+from transforms3d.transform_graph import Transformation, create_tranformation_graph
+import numpy as np
+import igraph as ig
+
+
+def test_create_tranformation_graph():
+
+    T = np.zeros((4,4))
+    wizard_transforms = [
+        Transformation("world", "left_hand", T),
+        Transformation("world", "right_hand", T),
+        Transformation("right_hand", "magic_stick", T),
+        Transformation("left_hand", "book", T),
+        Transformation("book", "page_corner", T)
+    ]
+
+    g = create_tranformation_graph(wizard_transforms)
+    assert isinstance(g, ig.Graph)

--- a/transforms3d/transform_graph.py
+++ b/transforms3d/transform_graph.py
@@ -12,30 +12,6 @@ class Transformation:
     A: np.ndarray  # 4x4 matrix for 3D affine trafo
 
 
-def _invert_tf(tf: Transformation) -> Transformation:
-
-    # we could use decompose
-    R = tf.A[:3, :3]
-    p = tf.A[:3, 3]
-
-    R_inv = np.linalg.inv(R)
-
-    A_inv = np.identity(4, dtype=float)
-    A_inv[:3, :3] = R_inv
-    A_inv[:3, 3] = - R_inv @ p
-
-    return Transformation(tf.target_frame, tf.source_frame, A_inv)
-
-
-def invert_transformations(transformations: List[Transformation]) -> List[Transformation]:
-
-    inverted_transformations = list()
-    for tf in transformations:
-        tf_inv = _invert_tf(tf)
-        inverted_transformations.append(tf_inv)
-    return inverted_transformations
-
-
 def create_tranformation_graph(transformations: List[Transformation]):
 
     unique_frames = set([tf.source_frame for tf in transformations] + [tf.target_frame for tf in transformations])
@@ -76,3 +52,26 @@ def pairwise(iterable):
     a, b = tee(iterable)
     next(b, None)
     return zip(a, b)
+
+
+def invert_transformations(transformations: List[Transformation]) -> List[Transformation]:
+
+    inverted_transformations = list()
+    for tf in transformations:
+        tf_inv = _invert_tf(tf)
+        inverted_transformations.append(tf_inv)
+    return inverted_transformations
+
+def _invert_tf(tf: Transformation) -> Transformation:
+
+    # we could use decompose (?)
+    R = tf.A[:3, :3]
+    p = tf.A[:3, 3]
+
+    R_inv = np.linalg.inv(R)
+
+    A_inv = np.identity(4, dtype=float)
+    A_inv[:3, :3] = R_inv
+    A_inv[:3, 3] = - R_inv @ p
+
+    return Transformation(tf.target_frame, tf.source_frame, A_inv)

--- a/transforms3d/transform_graph.py
+++ b/transforms3d/transform_graph.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import List
+from itertools import tee
+
+import numpy as np
+import igraph as ig
+
+@dataclass
+class Transformation:
+    source_frame: str
+    target_frame: str
+    A: np.ndarray  # 4x4 matrix for 3D affine trafo
+
+
+def create_tranformation_graph(transformations: List[Transformation]):
+
+    unique_frames = set([tf.source_frame for tf in transformations] + [tf.target_frame for tf in transformations])
+
+    unique_frames_map = {i: f for f, i in enumerate(list(unique_frames))}
+    unique_frames_map_reverse = {v: k for k, v in unique_frames_map.items()}
+
+    tf_pairs_as_ids = set([(unique_frames_map[tf.source_frame], unique_frames_map[tf.target_frame]) \
+        for tf in transformations])
+
+    tf_graph = ig.Graph(len(unique_frames), list(tf_pairs_as_ids))
+    tf_graph.vs["name"] = [unique_frames_map_reverse[i] for i in range(len(unique_frames))]
+
+    return tf_graph
+
+
+def pairwise(iterable):
+    # pairwise('ABCDEFG') --> AB BC CD DE EF FG
+    a, b = tee(iterable)
+    next(b, None)
+    return zip(a, b)

--- a/transforms3d/transform_graph.py
+++ b/transforms3d/transform_graph.py
@@ -12,20 +12,61 @@ class Transformation:
     A: np.ndarray  # 4x4 matrix for 3D affine trafo
 
 
+def _invert_tf(tf: Transformation) -> Transformation:
+    R = tf.A[:3, :3]
+    p = tf.A[:3, 3]
+
+    R_inv = np.linalg.inv(R)
+
+    A_inv = np.identity(4, dtype=float)
+    A_inv[:3, :3] = R_inv
+    A_inv[:3, 3] = - R_inv @ p
+
+    return Transformation(tf.target_frame, tf.source_frame, A_inv)
+
+
+def invert_transformations(transformations: List[Transformation]) -> List[Transformation]:
+
+    inverted_transformations = list()
+    for tf in transformations:
+        tf_inv = _invert_tf(tf)
+        inverted_transformations.append(tf_inv)
+    return inverted_transformations
+
+
 def create_tranformation_graph(transformations: List[Transformation]):
 
     unique_frames = set([tf.source_frame for tf in transformations] + [tf.target_frame for tf in transformations])
+    unique_frames = list(unique_frames)
 
-    unique_frames_map = {i: f for f, i in enumerate(list(unique_frames))}
-    unique_frames_map_reverse = {v: k for k, v in unique_frames_map.items()}
+    unique_frames_map = {i: frame for i, frame in enumerate(unique_frames)}
+    unique_frames_map_reverse = {frame: i for i, frame in unique_frames_map.items()}
 
-    tf_pairs_as_ids = set([(unique_frames_map[tf.source_frame], unique_frames_map[tf.target_frame]) \
-        for tf in transformations])
+    transformations_inv = invert_transformations(transformations)
+    transformations_all = transformations_inv + transformations
 
-    tf_graph = ig.Graph(len(unique_frames), list(tf_pairs_as_ids))
-    tf_graph.vs["name"] = [unique_frames_map_reverse[i] for i in range(len(unique_frames))]
+    tf_pairs_as_ids = [(unique_frames_map_reverse[tf.source_frame], unique_frames_map_reverse[tf.target_frame]) \
+        for tf in transformations_all]
+
+    # TODO check for duplicates
+
+    tf_graph = ig.Graph(len(unique_frames), tf_pairs_as_ids, directed=True)
+    tf_graph.vs["name"] = unique_frames
+
+    tf_graph.es["A"] = [tf.A for tf in transformations_all]
 
     return tf_graph
+
+
+def get_tranformation_matrix(tf_graph: ig.Graph, source: str, target: str) -> List[int]:
+
+    vertices_on_path = tf_graph.get_shortest_paths(source, to=target, mode="out", output='vpath')[0]
+    
+    H = np.ones((4, 4), dtype=float)
+    for e0, e1 in pairwise(vertices_on_path):
+        edge = tf_graph.es.find(_source=e0, _target=e1)
+        H = H @ edge["A"]
+    return H
 
 
 def pairwise(iterable):

--- a/transforms3d/transform_graph.py
+++ b/transforms3d/transform_graph.py
@@ -13,6 +13,8 @@ class Transformation:
 
 
 def _invert_tf(tf: Transformation) -> Transformation:
+
+    # we could use decompose
     R = tf.A[:3, :3]
     p = tf.A[:3, 3]
 
@@ -62,7 +64,7 @@ def get_tranformation_matrix(tf_graph: ig.Graph, source: str, target: str) -> Li
 
     vertices_on_path = tf_graph.get_shortest_paths(source, to=target, mode="out", output='vpath')[0]
     
-    H = np.ones((4, 4), dtype=float)
+    H = np.identity(4)
     for e0, e1 in pairwise(vertices_on_path):
         edge = tf_graph.es.find(_source=e0, _target=e1)
         H = H @ edge["A"]


### PR DESCRIPTION
ROS has a [very helpful](http://wiki.ros.org/tf/Tutorials/Introduction%20to%20tf) functionality transforming back and forth between coordinate systems, which may be helpful for many spatial (data-) analyses outside of robotics domain.

In the picture below an example is shown, where given the transformations of both `plane` and `balloon` relative to `world` a transformation `plane<->balloon` can be created automatically.

![image](https://user-images.githubusercontent.com/12762439/199097859-ef7c3990-9ab5-4120-9ec6-3326671920d3.png)

The corresponding TF graph would look like:

![image](https://user-images.githubusercontent.com/12762439/199101130-a596a3c5-0c9d-4f1e-838d-9bc94cb3d6dc.png)

Imagine answer questions like _what is the location of p in balloon's coordinates when the plane sees it in x=100m distance_?

This PR includes:

- create a TF tree from a list of named transforms
- create a homogenous transform matrix from coordinate system X -> Y (if both X, Y are connected in the graph)

This PR is a first draft, feel free to comment whether this functionality is in scope of transforms3d ...


