### PR TITLE
Refactor some functions to support batch invocation on numpy arrays

### DIFF
--- a/transforms3d/affines.py
+++ b/transforms3d/affines.py
@@ -5,6 +5,7 @@ import math
 import numpy as np
 
 from .shears import striu2mat
+from .utils import diag_2d, transpose_2d, unpack
 
 
 def decompose44(A44):
@@ -27,24 +28,24 @@ def decompose44(A44):
     The order of transformations is therefore shears, followed by
     zooms, followed by rotations, followed by translations.
 
-    This routine only works for shape (4,4) matrices
+    This routine only works for shape (..., 4,4) matrices
 
     Parameters
     ----------
-    A44 : array shape (4,4)
+    A44 : array shape (..., 4,4)
 
     Returns
     -------
-    T : array, shape (3,)
-       Translation vector
-    R : array shape (3,3)
+    T : array, shape (..., 3,)
+        Translation vector
+    R : array shape (..., 3,3)
         rotation matrix
-    Z : array, shape (3,)
-       Zoom vector.  May have one negative zoom to prevent need for negative
-       determinant R matrix above
-    S : array, shape (3,)
-       Shear vector, such that shears fill upper triangle above
-       diagonal to form shear matrix (type ``striu``).
+    Z : array, shape (..., 3)
+        Zoom vector.  May have one negative zoom to prevent need for negative
+        determinant R matrix above
+    S : array, shape (..., 3)
+        Shear vector, such that shears fill upper triangle above
+        diagonal to form shear matrix (type ``striu``).
 
     Examples
     --------
@@ -122,35 +123,45 @@ def decompose44(A44):
     unknowns.
     '''
     A44 = np.asarray(A44)
-    T = A44[:-1,-1]
-    RZS = A44[:-1,:-1]
+    T = A44[..., :-1,-1]
+    RZS = A44[..., :-1,:-1]
+
     # compute scales and shears
-    M0, M1, M2 = np.array(RZS).T
+    M0, M1, M2 = unpack(transpose_2d(RZS.copy()), axis=-2)
+
     # extract x scale and normalize
-    sx = math.sqrt(np.sum(M0**2))
-    M0 /= sx
+    sx = np.sqrt(np.sum(M0**2, axis=-1))
+    M0 /= sx[..., np.newaxis]
+
     # orthogonalize M1 with respect to M0
-    sx_sxy = np.dot(M0, M1)
+    sx_sxy = np.vdot(M0, M1)
     M1 -= sx_sxy * M0
+
     # extract y scale and normalize
-    sy = math.sqrt(np.sum(M1**2))
-    M1 /= sy
+    sy = np.sqrt(np.sum(M1**2, axis=-1))
+    M1 /= sy[..., np.newaxis]
     sxy = sx_sxy / sx
+
     # orthogonalize M2 with respect to M0 and M1
-    sx_sxz = np.dot(M0, M2)
-    sy_syz = np.dot(M1, M2)
+    sx_sxz = np.vdot(M0, M2)
+    sy_syz = np.vdot(M1, M2)
     M2 -= (sx_sxz * M0 + sy_syz * M1)
+
     # extract z scale and normalize
-    sz = math.sqrt(np.sum(M2**2))
-    M2 /= sz
+    sz = np.sqrt(np.sum(M2**2, axis=-1))
+    M2 /= sz[..., np.newaxis]
     sxz = sx_sxz / sx
     syz = sy_syz / sy
+
     # Reconstruct rotation matrix, ensure positive determinant
-    Rmat = np.array([M0, M1, M2]).T
-    if np.linalg.det(Rmat) < 0:
-        sx *= -1
-        Rmat[:,0] *= -1
-    return T, Rmat, np.array([sx, sy, sz]), np.array([sxy, sxz, syz])
+    Rmat = transpose_2d(np.stack([M0, M1, M2], axis=-2))
+    Rsign = np.sign(np.linalg.det(Rmat))
+    sx *= Rsign
+    Rmat[..., :,0] *= Rsign[..., np.newaxis]
+
+    Z = np.stack([sx, sy, sz], axis=-1)
+    S = np.stack([sxy, sxz, syz], axis=-1)
+    return T, Rmat, Z, S
 
 
 def decompose(A):
@@ -251,20 +262,20 @@ def compose(T, R, Z, S=None):
 
     Parameters
     ----------
-    T : array-like shape (N,)
+    T : array-like shape (..., N,)
         Translations, where N is usually 3 (3D case)
-    R : array-like shape (N,N)
+    R : array-like shape (..., N,N)
         Rotation matrix where N is usually 3 (3D case)
-    Z : array-like shape (N,)
+    Z : array-like shape (..., N,)
         Zooms, where N is usually 3 (3D case)
-    S : array-like, shape (P,), optional
-       Shear vector, such that shears fill upper triangle above
-       diagonal to form shear matrix.  P is the (N-2)th Triangular
-       number, which happens to be 3 for a 4x4 affine (3D case)
+    S : array-like, shape (..., P,), optional
+        Shear vector, such that shears fill upper triangle above
+        diagonal to form shear matrix.  P is the (N-2)th Triangular
+        number, which happens to be 3 for a 4x4 affine (3D case)
 
     Returns
     -------
-    A : array, shape (N+1, N+1)
+    A : array, shape (..., N+1, N+1)
         Affine transformation matrix where N usually == 3
         (3D case)
 
@@ -292,14 +303,22 @@ def compose(T, R, Z, S=None):
            [0., 0., 1., 0.],
            [0., 0., 0., 1.]])
     '''
-    n = len(T)
+    T = np.asarray(T)
     R = np.asarray(R)
-    if R.shape != (n,n):
-        raise ValueError('Expecting shape (%d,%d) for rotations' % (n,n))
-    A = np.eye(n+1)
-    ZS = np.diag(Z)
-    if not S is None:
-        ZS = ZS.dot(striu2mat(S))
-    A[:n,:n] = np.dot(R, ZS)
-    A[:n,n] = T[:]
+    Z = np.asarray(Z)
+
+    *batches, n = T.shape
+    if R.shape[-2:] != (n, n):
+        raise ValueError('Expecting shape (..., %d, %d) for rotations' % (n, n))
+
+    A = np.zeros((*batches, n+1, n+1))
+
+    ZS = diag_2d(Z)
+    if S is not None:
+        ZS = ZS @ striu2mat(S)
+    
+    A[..., :n,:n] = R @ ZS
+    A[..., :n, n] = T[:]
+    A[...,  n, n] = 1
+    
     return A

--- a/transforms3d/utils.py
+++ b/transforms3d/utils.py
@@ -158,3 +158,82 @@ def random_unit_vector(rng=None):
     if rng is None:
         rng = np_default_rng()
     return normalized_vector(rng.normal(size=3))
+
+
+def unpack(array, axis=-1, keepdim=False):
+    ''' Unpack an array along the given axis
+
+    Parameters
+    ----------
+    array : array-like with arbitrary shape (..., N, ...)
+    axis : axis to unpack
+    keepdim: keep a dimension of length 1 at `axis` position
+
+    Returns
+    -------
+    out : np.ndarray with shape (N, ...)
+       array with the given axis moved to the front, meant to be passed to Python unpacking
+
+    Examples
+    --------
+    >>> a, b = unpack([[1, 2], [3, 4], [5, 6]], axis=-1)
+    >>> a
+    array([1, 3, 5])
+    >>> b
+    array([2, 4, 6])
+    '''
+    array = np.asarray(array)
+    array = np.rollaxis(array, axis)
+    if keepdim:
+        array = np.expand_dims(array, axis)
+    return array
+
+
+def diag_2d(v):
+    ''' Construct batches of diagonal matrices
+
+    Parameters
+    ----------
+    v : array-like batch of vectors with shape (..., N)
+
+    Returns
+    -------
+    out : np.ndarray with shape (..., N, N)
+       batch of matrices with v on the diagonal
+       
+    Examples
+    --------
+    >>> a = np.ones((128, 3))
+    >>> b = diag_2d(a)
+    >>> b.shape
+    (128, 3, 3)
+    >>> np.allclose(b[0], np.diag(a[0]))
+    True
+    '''
+    *batches, n = v.shape
+    diag_indices = tuple([..., *np.diag_indices(n)])
+    out = np.zeros((*batches, n, n))
+    out[diag_indices] = v
+    return out
+
+
+def transpose_2d(array):
+    ''' Transpose batches of 2D arrays
+
+    Parameters
+    ----------
+    array : array-like batch of 2D arrays with shape (..., N, M)
+
+    Returns
+    -------
+    out : np.ndarray with shape (..., M, N)
+       array with the last two dimensions transposed
+       
+    Examples
+    --------
+    >>> a = np.zeros((128, 2, 3))
+    >>> b = transpose_2d(a)
+    >>> b.shape
+    (128, 3, 2)
+    '''
+    return np.transpose(array, (*range(array.ndim - 2), -1, -2))


### PR DESCRIPTION
This commit provides vectorized implementations for the following functions:
- `affines.compose`
- `affines.decompose44`
- `euler.euler2mat`
- `euler.mat2euler`

I tried to keep the code as close as possible to the current implementation, using idiomatic Numpy code to handle scalars and batches in a single code path. The functions accept inputs with an arbitrary number of batch dimensions in front of the expected input shape. Functions that expect a (3, 3) matrix, for example, will accept arrays with shape (..., 3, 3).

I propose to discuss any changes to bring these to a mergeable state, then same approach can be used to vectorize other functions in the library.

The changes should be backwards compatible and entirely transparent for existing users. Existing tests all pass, let me know if you had something specific in mind on additional tests for this functionality in #14.