### PR TITLE
Fixed qinverse function

### DIFF
--- a/transforms3d/quaternions.py
+++ b/transforms3d/quaternions.py
@@ -301,7 +301,7 @@ def qinverse(q):
     invq : array shape (4,)
        w, i, j, k of quaternion inverse
     '''
-    return qconjugate(q) / qnorm(q)
+    return qconjugate(q) / qnorm(q) ** 2
 
 
 def qeye(dtype=np.float64):


### PR DESCRIPTION
The denominator should be squared qnorm instead of qnorm (although the original version works for unit quaternions).