### PR TITLE
Add a “derivations” extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,11 @@ dependencies = [
     "numpy >=1.15",
 ]
 
+[project.optional-dependencies]
+derivations = [
+    "sympy",
+]
+
 [tool.setuptools.packages.find]
 include = ["transforms3d*"]
 


### PR DESCRIPTION
Use an extra to declare optional dependencies (currently, `sympy`) that are only used for the derivations.

Currently, `sympy` is listed only as a test dependency in `test-requirements.txt`, which isn’t completely accurate, since it’s used throughout `transforms3d.derivations`. However, it’s a fairly heavy-weight dependency, and isn’t needed at all for users that don’t need to import from `transforms3d.derivations`. Adding the extra means that users who *do* plan to use derivations can depend on `transforms3d[derivations]` rather than having to add a direct dependency on `sympy`.

In the [`python-transforms3d` package](https://src.fedoraproject.org/rpms/python-transforms3d) in Fedora, we currently deal with the use of `sympy` in the derivations by adding a weak dependency on `sympy` to the `python3-transforms3d` package, but these weak dependencies still installed by default – and `sympy` has its own weak dependency on a LaTeX environment, so all of TeXLive is pulled in. With a `derivations` extra, we could drop the weak dependency and offer a `python3-transforms3d+derivations` [metapackage](https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#Extras) instead.