### PR TITLE
set  default value for arg Z of compose()

### DIFF
--- a/transforms3d/affines.py
+++ b/transforms3d/affines.py
@@ -246,7 +246,7 @@ def decompose(A):
     return T, R, Z, S
 
 
-def compose(T, R, Z, S=None):
+def compose(T, R, Z=None, S=None):
     ''' Compose translations, rotations, zooms, [shears]  to affine
 
     Parameters
@@ -256,7 +256,7 @@ def compose(T, R, Z, S=None):
     R : array-like shape (N,N)
         Rotation matrix where N is usually 3 (3D case)
     Z : array-like shape (N,)
-        Zooms, where N is usually 3 (3D case)
+        Zooms, where N is usually 3 (3D case). If None, then set value as np.ones(N).
     S : array-like, shape (P,), optional
        Shear vector, such that shears fill upper triangle above
        diagonal to form shear matrix.  P is the (N-2)th Triangular
@@ -296,6 +296,8 @@ def compose(T, R, Z, S=None):
     if R.shape != (n,n):
         raise ValueError('Expecting shape (%d,%d) for rotations' % (n,n))
     A = np.eye(n+1)
+    if Z is None:
+        Z = np.ones(n)
     ZS = np.diag(Z)
     if not S is None:
         ZS = ZS.dot(striu2mat(S))


### PR DESCRIPTION
**Proposed Change:**

Introduce a default value for the `Z` parameter in the `compose()` function. When `Z` is set to `None`, it will be assumed to be `np.ones(N)`. This modification will simplify the creation of common homogeneous transformation matrices, such as `compose(T, R)`, which are widely used in robotics.

**Justification:**

Currently, the `compose()` function requires explicit specification of the `Z` parameter, even for simple transformations like `compose(T, R)`. This can be cumbersome and error-prone, as users may forget to include `Z` or pass an incorrect value.

Setting a default value of `np.ones(N)` for `Z` will address these issues by providing a convenient way to create homogeneous transformation matrices without the need for explicit `Z` specification. This will align with common usage patterns in robotics and other fields.

**Benefits:**

- **Simplified function usage:** Users can easily create common homogeneous transformation matrices without explicitly specifying `Z`.

- **Reduced error potential:** The risk of forgetting or providing an incorrect `Z` value is minimized.

- **Improved code readability:** Code using `compose()` will be more concise and easier to understand.

**Impact:**

This change will primarily affect users who rely on `compose()` to create homogeneous transformation matrices. It will introduce a new default behavior for the `Z` parameter, but this behavior aligns with common usage scenarios and simplifies the function's usage.

**Overall, the proposed change enhances the usability and convenience of the `compose()` function, particularly for creating common homogeneous transformation matrices.**